### PR TITLE
Change shebang line to use /usr/bin/env

### DIFF
--- a/bin/arson
+++ b/bin/arson
@@ -1,4 +1,4 @@
-#!/usr/bin/ruby
+#!/usr/bin/env ruby
 
 $:.unshift(File.expand_path(File.join(File.dirname(__FILE__), '..', 'lib')))
 $stdout.sync = true


### PR DESCRIPTION
Here's the first of the patches I messaged you about earlier.. I did manage to break the mass into a couple of topic branches after all.

This first one just changes the shebang line of bin/arson to read #!/usr/bin/env ruby, to make it play nicer with rubies that are installed elsewhere.
