### PR TITLE
Fix config for ruby19

### DIFF
--- a/bin/arson
+++ b/bin/arson
@@ -101,7 +101,7 @@ when :search || nil
 	end
 end
 
-Arson::Config.write if Arson::Config.modified
+Arson::Config.write if Arson::Config.modified?
 if Arson::Config["run_pacman"]
 	print ">> Running pacman" if options[:debug]
 	if File.exists? "/usr/bin/pacman-color" and Arson::Config["color"]

--- a/lib/arson/config.rb
+++ b/lib/arson/config.rb
@@ -17,13 +17,14 @@ class Arson
 
 		# Returns the value for that configuration option (as a string)
 		def self.[](option)
-			value = MERGED[option.to_s]
+                        optstr = option.to_s
+			value = MERGED[optstr]
 			
 			# Hash#merge() overwrites the value, even if it's an
 			# empty string or nil. Therefore, check if the user has a
 			# nil value in their configuration and update the hash.
 			if value.nil? or value.empty?
-				MERGED[option.to_s] = DEFAULTS[option.to_s]
+				MERGED[optstr] = DEFAULTS[optstr]
 				@modified = true
 			end
 

--- a/lib/arson/config.rb
+++ b/lib/arson/config.rb
@@ -27,8 +27,7 @@ class Arson
 			# Hash#merge() overwrites the value, even if it's an
 			# empty string or nil. Therefore, check if the user has a
 			# nil value in their configuration and update the hash.
-			if value.nil? or (value.respond_to?(:empty?)
-                                          and value.empty?)
+			if value.nil? or (value.respond_to?(:empty?) and value.empty?)
 				MERGED[optstr] = DEFAULTS[optstr]
 				@@modified = true
 			end

--- a/lib/arson/config.rb
+++ b/lib/arson/config.rb
@@ -48,3 +48,5 @@ class Arson
 		end
 	end
 end
+
+# vim: sw=8 sts=8 et

--- a/lib/arson/config.rb
+++ b/lib/arson/config.rb
@@ -3,7 +3,11 @@ require 'yaml'
 class Arson
 	module Config
 
-		attr_reader :modified
+                @@modified = false
+                
+                def self.modified?
+                        @@modified
+                end
 
 		# The location of the configuration file (hard coded for now)
 		FILE_PATH = File.expand_path(File.join("~", ".arson.yaml"))
@@ -26,7 +30,7 @@ class Arson
 			if value.nil? or (value.respond_to?(:empty?)
                                           and value.empty?)
 				MERGED[optstr] = DEFAULTS[optstr]
-				@modified = true
+				@@modified = true
 			end
 
 			return value

--- a/lib/arson/config.rb
+++ b/lib/arson/config.rb
@@ -23,7 +23,8 @@ class Arson
 			# Hash#merge() overwrites the value, even if it's an
 			# empty string or nil. Therefore, check if the user has a
 			# nil value in their configuration and update the hash.
-			if value.nil? or value.empty?
+			if value.nil? or (value.respond_to?(:empty?)
+                                          and value.empty?)
 				MERGED[optstr] = DEFAULTS[optstr]
 				@modified = true
 			end


### PR DESCRIPTION
The Config module was not working for me in Ruby 1.9, these changes fix it. I changed the attr_reader definition to a class method "modified?" accessing the class var "@@modified". I also removed a bit or repetition from Config::[].
