### PR TITLE
Trollop, logging and facets fixes

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -42,3 +42,5 @@ end
 CLASS
 	end
 end
+
+# vim: sw=8 sts=8 noet

--- a/Rakefile
+++ b/Rakefile
@@ -22,6 +22,7 @@ begin
 		gemspec.add_dependency('archive-tar-minitar', '>= 0.5.2')
 		gemspec.add_dependency('versionomy', '>= 0.4.0')
 		gemspec.add_dependency('ansi', '>= 1.2.2')
+		gemspec.add_dependency('trollop', '>= 1.16.2')
 	end
 rescue LoadError
 	puts "Jeweler not available. Install it with: sudo gem install technicalpickles-jeweler -s http://gems.github.com"

--- a/Rakefile
+++ b/Rakefile
@@ -23,6 +23,7 @@ begin
 		gemspec.add_dependency('versionomy', '>= 0.4.0')
 		gemspec.add_dependency('ansi', '>= 1.2.2')
 		gemspec.add_dependency('trollop', '>= 1.16.2')
+		gemspec.add_dependency('simple_progressbar', '>= 0.1.3')
 	end
 rescue LoadError
 	puts "Jeweler not available. Install it with: sudo gem install technicalpickles-jeweler -s http://gems.github.com"

--- a/Rakefile
+++ b/Rakefile
@@ -19,9 +19,9 @@ begin
 		gemspec.executables = ["arson"]
 
 		gemspec.add_dependency('json', '>= 1.1.3')
-		gemspec.add_dependency('facets', '>= 2.5.1')
 		gemspec.add_dependency('archive-tar-minitar', '>= 0.5.2')
 		gemspec.add_dependency('versionomy', '>= 0.4.0')
+		gemspec.add_dependency('ansi', '>= 1.2.2')
 	end
 rescue LoadError
 	puts "Jeweler not available. Install it with: sudo gem install technicalpickles-jeweler -s http://gems.github.com"

--- a/Rakefile
+++ b/Rakefile
@@ -21,6 +21,7 @@ begin
 		gemspec.add_dependency('json', '>= 1.1.3')
 		gemspec.add_dependency('facets', '>= 2.5.1')
 		gemspec.add_dependency('archive-tar-minitar', '>= 0.5.2')
+		gemspec.add_dependency('versionomy', '>= 0.4.0')
 	end
 rescue LoadError
 	puts "Jeweler not available. Install it with: sudo gem install technicalpickles-jeweler -s http://gems.github.com"

--- a/Rakefile
+++ b/Rakefile
@@ -20,6 +20,7 @@ begin
 
 		gemspec.add_dependency('json', '>= 1.1.3')
 		gemspec.add_dependency('facets', '>= 2.5.1')
+		gemspec.add_dependency('archive-tar-minitar', '>= 0.5.2')
 	end
 rescue LoadError
 	puts "Jeweler not available. Install it with: sudo gem install technicalpickles-jeweler -s http://gems.github.com"

--- a/bin/arson
+++ b/bin/arson
@@ -6,6 +6,10 @@ $stdout.sync = true
 require 'arson'
 require 'arson/colorful'
 require 'optparse'
+require 'logger'
+
+$Log = Logger.new STDOUT
+$Log.level = Logger::WARN
 
 # Check if the YAML is outdated or doesn't exist. In either case, write the YAML
 # again.

--- a/bin/arson
+++ b/bin/arson
@@ -63,7 +63,8 @@ EOS
 	   when 'upgrade'
 		   Trollop::options do
 			   banner <<-EOS
-Upgrade named  packages.
+Look for upgradeable packages. If no package names are given, search
+for upgrades to all packages installed from AUR.
 EOS
 		   end
 	   else

--- a/bin/arson
+++ b/bin/arson
@@ -79,7 +79,7 @@ $Log.debug "Subcommand arguments: #{ARGV}"
 case cmd
 when "upgrade"
 	print "Checking for upgrades..."
-	upgrades = Arson.check_upgrades
+	upgrades = Arson.check_upgrades ARGV
 	unless upgrades.empty?
 		print "\n"
 		upgrades.each do |line, new_version|
@@ -89,6 +89,10 @@ when "upgrade"
 		puts "Nothing to update"
 	end
 when "download"
+	if ARGV.empty?
+		puts "No package names given"
+		exit 2
+	end
 	ARGV.each do |pkg|
 		if pkg = Arson.find_exact(pkg)
 			$Log.info "Downloading #{pkg}"
@@ -99,6 +103,10 @@ when "download"
 		end
 	end
 when "search"
+	if ARGV.empty?
+		puts "No search terms given"
+		exit 2
+	end
 	Arson.search(ARGV).each do |pkg|
 		name = Arson.colorful("White", pkg['Name'])
 		name = Arson.colorful("Red", name) if pkg["OutOfDate"] == "1"

--- a/bin/arson
+++ b/bin/arson
@@ -66,6 +66,9 @@ EOS
 Upgrade named  packages.
 EOS
 		   end
+	   else
+		   warn "Unknown command: #{cmd}"
+		   exit 1
 	   end
 
 $Log.level = Logger::INFO if global_opts[:verbose]

--- a/bin/arson
+++ b/bin/arson
@@ -5,11 +5,12 @@ $stdout.sync = true
 
 require 'arson'
 require 'arson/colorful'
-require 'optparse'
+require 'trollop'
 require 'logger'
 
 $Log = Logger.new STDOUT
 $Log.level = Logger::WARN
+$Log.progname = "Arson"
 
 # Check if the YAML is outdated or doesn't exist. In either case, write the YAML
 # again.
@@ -20,51 +21,63 @@ if (Arson::Config::LOADED_YAML and (Arson::Config::LOADED_YAML.keys.sort != Arso
 	Arson::Config.write
 end
 
-options = Hash.new(nil)
-options[:download] = 0
-ARGV.unshift "-h" if ARGV.empty?
-opts = OptionParser.new do |opts|
-	opts.banner = "Usage: arson [options]"
+global_opts = Trollop::options do
+	version <<-EOS
+arson v#{Arson::VERSION.join('.')}
+Copyright (C) 2008 Colin Shea <colin@evaryont.me>
+Licensed under the GPLv3, all rights reserved
+EOS
+	banner <<-EOS
+Arson, the hot AUR search helper.
 
-	opts.on("-s", "--search", "Search for packages") do
-		options[:action] ||= :search
-	end
+Usage: arson [ OPTIONS ] search TERM
+       arson [ OPTIONS ] download PACKAGE [ PACKAGE ... ]
+       arson [ OPTIONS ] upgrade [ PACKAGE ... ]
 
-	opts.on("-d", "--download", "Download the exact package name", "Repeating this will download other dependencies in AUR") do
-		options[:action] || :download
-		options[:download] += 1
-	end
+For help on individual commands, try 'arson COMMAND --help'.
 
-	opts.on("-u", "--upgrade", "Check for upgrades") do
-		options[:action] ||= :upgrade
-	end
-
-	opts.on("--debug", "Enable debugging statements") do
-		options[:debug] = true
-	end
-
-	opts.on_tail("-h", "--help", "Show this message") do
-		puts opts
-		exit 0
-	end
-
-	opts.on_tail("--version", "Show version") do
-		puts "arson v#{Arson::VERSION.join('.')}"
-		puts "Copyright (C) 2008 Colin Shea <colin@evaryont.me>"
-		puts "Licensed under the GPLv3, all rights reserved"
-		exit 0
-	end
-
-end.parse!
-p ARGV if options[:debug]
-
-if options[:action] and ARGV.empty?
-	warn "arson: Missing names of packages"
-	exit 1
+OPTIONS can be one or more of the following:
+EOS
+	opt :verbose, "Be more verbose", :short => '-v'
+	opt :debug, "Be even more verbose", :short => '-d'
+	stop_on %w(search download upgrade)
 end
 
-case options[:action]
-when :upgrade
+cmd = ARGV.shift
+cmd_opts = case cmd
+	   when 'search'
+		   Trollop::options do
+			   banner <<-EOS
+Search for packages whose names contain the search term.
+EOS
+		   end
+	   when 'download'
+		   Trollop::options do
+			   banner <<-EOS
+Download named packages.
+
+Options:
+EOS
+			   opt :dependencies, "Also download direct dependencies", :short => '-D'
+		   end
+	   when 'upgrade'
+		   Trollop::options do
+			   banner <<-EOS
+Upgrade named  packages.
+EOS
+		   end
+	   end
+
+$Log.level = Logger::INFO if global_opts[:verbose]
+$Log.level = Logger::DEBUG if global_opts[:debug]
+
+$Log.debug "Global options: #{global_opts}"
+$Log.debug "Subcommand: #{cmd}"
+$Log.debug "Subcommand options: #{cmd_opts}"
+$Log.debug "Subcommand arguments: #{ARGV}"
+
+case cmd
+when "upgrade"
 	print "Checking for upgrades..."
 	upgrades = Arson.check_upgrades
 	unless upgrades.empty?
@@ -75,20 +88,17 @@ when :upgrade
 	else
 		puts "Nothing to update"
 	end
-	exit 0
-when :download
-	exit_code = 0
+when "download"
 	ARGV.each do |pkg|
 		if pkg = Arson.find_exact(pkg)
 			p pkg if options[:debug]
 			Arson.download(pkg)
 		else
 			warn "arson: No such package '#{pkg}'"
-			exit_code = 1
+			exit 1
 		end
 	end
-	exit exit_code
-when :search || nil
+when "search"
 	Arson.search(ARGV).each do |pkg|
 		name = Arson.colorful("White", pkg['Name'])
 		name = Arson.colorful("Red", name) if pkg["OutOfDate"] == "1"
@@ -115,3 +125,5 @@ if Arson::Config["run_pacman"]
 		exec "/usr/bin/pacman -Ss #{ARGV.join(' ')}"
 	end
 end
+
+# vim: sw=8 sts=8 noet

--- a/bin/arson
+++ b/bin/arson
@@ -91,8 +91,8 @@ when "upgrade"
 when "download"
 	ARGV.each do |pkg|
 		if pkg = Arson.find_exact(pkg)
-			p pkg if options[:debug]
-			Arson.download(pkg)
+			$Log.info "Downloading #{pkg}"
+			Arson.download(pkg, cmd_opts[:dependencies])
 		else
 			warn "arson: No such package '#{pkg}'"
 			exit 1

--- a/lib/arson.rb
+++ b/lib/arson.rb
@@ -5,6 +5,7 @@ require 'json'
 require 'ansi'
 require 'archive/tar/minitar'
 require 'versionomy'
+require 'simple_progressbar'
 
 require 'arson/version'
 require 'arson/config'

--- a/lib/arson.rb
+++ b/lib/arson.rb
@@ -3,7 +3,7 @@ require 'zlib'
 require 'rubygems'
 require 'json'
 require 'facets/ansicode'
-require 'facets/minitar'
+require 'archive/tar/minitar'
 require 'facets/version'
 
 require 'arson/version'

--- a/lib/arson.rb
+++ b/lib/arson.rb
@@ -4,7 +4,7 @@ require 'rubygems'
 require 'json'
 require 'facets/ansicode'
 require 'archive/tar/minitar'
-require 'facets/version'
+require 'versionomy'
 
 require 'arson/version'
 require 'arson/config'

--- a/lib/arson.rb
+++ b/lib/arson.rb
@@ -2,7 +2,7 @@ require 'open-uri'
 require 'zlib'
 require 'rubygems'
 require 'json'
-require 'facets/ansicode'
+require 'ansi'
 require 'archive/tar/minitar'
 require 'versionomy'
 

--- a/lib/arson/colorful.rb
+++ b/lib/arson/colorful.rb
@@ -5,14 +5,16 @@ class Arson
 			colored = ""
 			if color.is_a? String
 				Colors[color].each do |effect|
-					colored << "#{::ANSICode.send(effect)}"
+					colored << "#{::ANSI::Code.send(effect)}"
 				end
 			elsif color.is_a? Symbol
-				colored << "#{::ANSICode.send(color)}"
+				colored << "#{::ANSI::Code.send(color)}"
 			else
 				return colorful(color.to_s, string)
 			end
-			colored << (string || "") << "#{::ANSICode.clear}"
+			colored << (string || "") << "#{::ANSI::Code.clear}"
 		end
 	end
 end
+
+# vim: sw=8 sts=8 noet

--- a/lib/arson/download.rb
+++ b/lib/arson/download.rb
@@ -4,7 +4,7 @@ class Arson
 		# RPC returns.
 		# TODO: Add automatic dependency tracking (gleaned parsing the PKGBUILD)
 		def download(package, get_dependencies=false)
-			puts "Downloading #{packages.first['Name']} to #{Arson::Config.directory_name}..."
+			puts "Downloading #{package['Name']} to #{Arson::Config.directory_name}..."
 			begin
 				real_download("http://aur.archlinux.org"+package['URLPath'])
 				if get_dependencies

--- a/lib/arson/download.rb
+++ b/lib/arson/download.rb
@@ -11,7 +11,7 @@ class Arson
 					dependencies = File.readlines("#{Arson::Config["target_directory"]}/#{package['Name']}/PKGBUILD").grep(/^(?:make)*depends/).map{|l| l.match(/.*=\((.*)\)$/)[1].gsub("'", '').split(' ')}.flatten.uniq.sort.map{|dep| (dep.scan(/(.*?)[><=]{1,2}(.*)/).first || [dep]).first }
 					# Remove all those packages that are found in pacman's
 					# package database
-					dependencies.reject { |depend| !is_sync?(depend) }
+					dependencies.reject { |depend| available_via_pacman?(depend) }
 					puts "Download #{dependencies.size} dependencies... #{dependencies.inspect}"
 				end
 			rescue Errno::EEXIST => e

--- a/lib/arson/download.rb
+++ b/lib/arson/download.rb
@@ -3,16 +3,16 @@ class Arson
 		# +package+ is expected to be a Hash, matching the structure the AUR
 		# RPC returns.
 		# TODO: Add automatic dependency tracking (gleaned parsing the PKGBUILD)
-		def download(package, depends=0)
+		def download(package, get_dependencies=false)
 			puts "Downloading #{packages.first['Name']} to #{Arson::Config.directory_name}..."
 			begin
 				real_download("http://aur.archlinux.org"+package['URLPath'])
-				if depends > 0
-					dependences = File.readlines("#{Arson::Config["target_directory"]}/#{package['Name']}/PKGBUILD").grep(/^(?:make)*depends/).map{|l| l.match(/.*=\((.*)\)$/)[1].gsub("'", '').split(' ')}.flatten.uniq.sort.map{|dep| (dep.scan(/(.*?)[><=]{1,2}(.*)/).first || [dep]).first }
+				if get_dependencies
+					dependencies = File.readlines("#{Arson::Config["target_directory"]}/#{package['Name']}/PKGBUILD").grep(/^(?:make)*depends/).map{|l| l.match(/.*=\((.*)\)$/)[1].gsub("'", '').split(' ')}.flatten.uniq.sort.map{|dep| (dep.scan(/(.*?)[><=]{1,2}(.*)/).first || [dep]).first }
 					# Remove all those packages that are found in pacman's
 					# package database
-					dependences.reject { |depend| !is_sync?(depend) }
-					puts "Download #{dependences.size} dependences... #{dependences.inspect}"
+					dependencies.reject { |depend| !is_sync?(depend) }
+					puts "Download #{dependencies.size} dependencies... #{dependencies.inspect}"
 				end
 			rescue Errno::EEXIST => e
 				warn "arson: #{e.message}"
@@ -46,3 +46,5 @@ class Arson
 		end
 	end
 end
+
+# vim: sw=8 sts=8 noet

--- a/lib/arson/search.rb
+++ b/lib/arson/search.rb
@@ -34,8 +34,14 @@ class Arson
 				#                    [Categories[pkg['CategoryID'].to_i],pkg['Name']] - Category name, then pkg name
 				hash["results"].sort_by{|pkg|[pkg['Name']]}.each do |pkg|
 					# Dir["/var/lib/pacman/sync/community/#{pkg['Name']}-*"].first
-					next if File.exists? "/var/lib/pacman/sync/community/#{pkg['Name']}-#{pkg['Version']}"
-					return pkg if pkg['Name'] == arg
+					if File.exists? "/var/lib/pacman/sync/community/#{pkg['Name']}-#{pkg['Version']}"
+						$Log.debug "Skipping in-sync package #{pkg['Name']}"
+					elsif pkg['Name'] == arg
+						$Log.debug "Exact match found: #{pkg}"
+						return pkg
+					else
+						$Log.debug "Skipping partial match: #{pkg['Name']}"
+					end
 				end
 			end
 

--- a/lib/arson/search.rb
+++ b/lib/arson/search.rb
@@ -27,7 +27,6 @@ class Arson
 		# Attempts to find an exact matching package in AUR
 		def find_exact(arg)
 			hash = JSON.parse(open("http://aur.archlinux.org/rpc.php?type=search&arg=#{URI.escape(arg)}").read)
-			packages = []
 
 			if hash["type"] == "search"
 
@@ -64,3 +63,5 @@ class Arson
 		end
 	end
 end
+
+# vim: sw=8 sts=8 noet

--- a/lib/arson/upgrade.rb
+++ b/lib/arson/upgrade.rb
@@ -5,10 +5,10 @@ class Arson
 		#
 		# Calls `pacman -Qm', and given each line, finds upgrades for
 		# that package.
-		def check_upgrades
+		def check_upgrades(packages = [])
 			upgradable = Hash.new
 
-			::IO.popen('pacman -Qm', ::IO::RDONLY) {|pm| pm.read.lines}.each do |line|
+			::IO.popen("pacman -Qm #{packages.join(' ')}", ::IO::RDONLY) {|pm| pm.read.lines}.each do |line|
 				name, version = line.chomp.split
 				result = find_exact(name)
 

--- a/lib/arson/upgrade.rb
+++ b/lib/arson/upgrade.rb
@@ -13,7 +13,7 @@ class Arson
 				result = find_exact(name)
 
 				if result
-					if ::VersionNumber.new(result['Version']) > ::VersionNumber.new(version)
+					if ::Versiononmy::parse(result['Version']) > ::Versionomy::parse(version)
 						upgradable[line] = result['Version']
 					end
 				end
@@ -24,3 +24,5 @@ class Arson
 
 	end
 end
+
+# vim: sw=8 sts=8 noet

--- a/lib/arson/upgrade.rb
+++ b/lib/arson/upgrade.rb
@@ -15,7 +15,7 @@ class Arson
 					result = find_exact(name)
 
 					if result
-						if ::Versiononmy::parse(result['Version']) > ::Versionomy::parse(version)
+						if ::Versionomy::parse(result['Version']) > ::Versionomy::parse(version)
 							upgradable[line] = result['Version']
 						end
 					end


### PR DESCRIPTION
So, here's the big one. The option parsing is rewritten to use Trollop and to work via subcommands, like git or svn. Some libraries have since been removed from facets and put into their own gems, and I fixed the dependencies for these. To the point, in fact, where facets is no longer a dependency. I also quite fancy nice progress indicators so I added one to the upgrade action with simple_progressbar, and am going to add more.
